### PR TITLE
update to go 1.20, CGO_ENABLED=0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,11 +12,12 @@ jobs:
         goarch: [amd64, arm64]
     steps:
     - uses: actions/checkout@v3
-    - uses: wangyoucao577/go-release-action@v1.30
+    - uses: wangyoucao577/go-release-action@v1.38
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        goversion: "https://go.dev/dl/go1.19.1.linux-amd64.tar.gz"
+        goversion: "https://go.dev/dl/go1.20.4.linux-amd64.tar.gz"
         binary_name: "fetch-secrets"
+        pre_command: export CGO_ENABLED=0
         compress_assets: false


### PR DESCRIPTION
This allows us to run on alpine as well without requiring glibc, bump the action and golang along the way.