### PR TITLE
update pipeline permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   releases-matrix:
     name: Release Go Binary


### PR DESCRIPTION
Github has recently made a change where pipeline tokens no longer have write permissions by default, this enables the specific permissions needed for this project.

See their blog post for more details: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/