### PR TITLE
bump the golang version in the release workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        goversion: "https://go.dev/dl/go1.20.4.linux-amd64.tar.gz"
+        goversion: "https://go.dev/dl/go1.21.8.linux-amd64.tar.gz"
         binary_name: "fetch-secrets"
         pre_command: export CGO_ENABLED=0
         compress_assets: false


### PR DESCRIPTION
This was accidentally left on 1.20 when updating to 1.21