### PR TITLE
fix secret fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ go.work
 .DS_Store
 .idea
 *.env
+
+fetch-secrets

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	timeout         = 60 * time.Second
-	secretTagPrefix = "secret_"
+	secretTagPrefix = "secrets_"
 )
 
 var (
@@ -111,7 +111,7 @@ func getTags(ctx context.Context, iamClient iamClient, role string) ([]string, e
 	for _, t := range resp.Tags {
 		tag := *t.Key
 		if strings.HasPrefix(tag, secretTagPrefix) {
-			tags = append(tags, tag)
+			tags = append(tags, *t.Value)
 		}
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -147,8 +147,8 @@ func (s *FetchSecretsTestSuite) TestGetTags_Success() {
 			Value: stringPtr("tag-value"),
 		},
 		{
-			Key:   stringPtr("secret_tag-key"),
-			Value: stringPtr("secret-tag-value"),
+			Key:   stringPtr("secrets_tag-key"),
+			Value: stringPtr("secrets-tag-value"),
 		},
 	}
 
@@ -161,7 +161,7 @@ func (s *FetchSecretsTestSuite) TestGetTags_Success() {
 	assert.NoError(s.T(), err)
 	assert.NotEmpty(s.T(), result)
 	assert.Equal(s.T(), len(result), 1)
-	assert.Contains(s.T(), result, "secret_tag-key")
+	assert.Contains(s.T(), result, "secrets-tag-value")
 }
 
 func (s *FetchSecretsTestSuite) TestFetchSecretsByID_SecretsError() {


### PR DESCRIPTION
During the previous improvements in
https://github.com/slicelife/fetch-secrets/pull/6 the prefix was accidentally changed to "secret_" instead of "secrets_".

Additionally the tag key was used to look up the value of the secret where it should have been the key value, this has been fixed and tests updated.