### PR TITLE
feat: update GH actions to support Node.js 24

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         goos: [linux, darwin]
         goarch: [amd64, arm64]
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6.0.2
     - uses: wangyoucao577/go-release-action@v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
feat: update GH actions to support Node.js 24

---

## Issue / Motivation

Opened by the [Mass PR workflow](https://github.com/slicelife/github-workflows/actions/workflows/mass-pr.yml). See the short description above for context.

## Changes

See the commit on this PR. The full per-repo run details — counts, the largest diff, and the list of repos that were skipped — are in the **GitHub Actions run summary** of the Mass PR workflow that opened this PR.

## Impact Assessment

- [ ] **High**
- [ ] **Medium**
- [x] **Low**
